### PR TITLE
remove unneeded $response->sendHeaders(); at FileController::getFileAction()

### DIFF
--- a/src/Controller/Front/FileController.php
+++ b/src/Controller/Front/FileController.php
@@ -41,7 +41,6 @@ class FileController extends Controller
                 $response->headers->set('Content-Disposition', sprintf('attachment; filename="%s"', date('Y_m_d_H_i_s')));
             }
 
-            $response->sendHeaders();
             $response->setContent($file);
 
             return $response;


### PR DESCRIPTION
When `Response` object returned, the headers should already sent.