### PR TITLE
Replace deprecated MAINTAINER with LABEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
-MAINTAINER Muhammad Surya Ihsanuddin<surya.kejawen@gmail.com>
+LABEL maintainer="Muhammad Surya Ihsanuddin<surya.kejawen@gmail.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
The MAINTAINER instruction is deprecated.
See https://docs.docker.com/engine/reference/builder/#maintainer-deprecated